### PR TITLE
Tidy up of the UI, bugfix and added a camera

### DIFF
--- a/cameras.json
+++ b/cameras.json
@@ -2,85 +2,92 @@
     {
         "name": "DMC II 140",
         "focal_length": 0.092,
-        "sensor_size": 0.0000072,
+        "sensor_size": 7.2e-06,
         "pixels_along_track": 11200,
         "pixels_across_track": 12096
     },
     {
         "name": "DMC II 230",
         "focal_length": 0.092,
-        "sensor_size": 0.0000056,
+        "sensor_size": 5.6e-06,
         "pixels_along_track": 14140,
         "pixels_across_track": 15552
     },
     {
         "name": "DMC II 250",
         "focal_length": 0.092,
-        "sensor_size": 0.0000056,
+        "sensor_size": 5.6e-06,
         "pixels_along_track": 14016,
         "pixels_across_track": 16768
     },
     {
         "name": "DMC III",
         "focal_length": 0.092,
-        "sensor_size": 0.0000039,
+        "sensor_size": 3.9e-06,
         "pixels_along_track": 14592,
         "pixels_across_track": 25728
     },
     {
         "name": "IXU 1000",
         "focal_length": 0.055,
-        "sensor_size": 0.0000046,
+        "sensor_size": 4.6e-06,
         "pixels_along_track": 8708,
         "pixels_across_track": 11608
     },
     {
         "name": "UltraCam-D",
-        "focal_length": 0.100,
-        "sensor_size": 0.000009,
+        "focal_length": 0.1,
+        "sensor_size": 9e-06,
         "pixels_along_track": 7500,
         "pixels_across_track": 11500
     },
     {
         "name": "UltraCamEagle80mm",
-        "focal_length": 0.080,
-        "sensor_size": 0.0000052,
+        "focal_length": 0.08,
+        "sensor_size": 5.2e-06,
         "pixels_along_track": 13080,
         "pixels_across_track": 20010
     },
     {
         "name": "UltraCamEagle210mm",
-        "focal_length": 0.210,
-        "sensor_size": 0.0000052,
+        "focal_length": 0.21,
+        "sensor_size": 5.2e-06,
         "pixels_along_track": 13080,
         "pixels_across_track": 20010
     },
     {
         "name": "UltraCamLp",
-        "focal_length": 0.070,
-        "sensor_size": 0.000006,
+        "focal_length": 0.07,
+        "sensor_size": 6e-06,
         "pixels_along_track": 7920,
         "pixels_across_track": 11704
     },
     {
         "name": "UltraCam-X",
-        "focal_length": 0.100,
-        "sensor_size": 0.0000072,
+        "focal_length": 0.1,
+        "sensor_size": 7.2e-06,
         "pixels_along_track": 9420,
         "pixels_across_track": 14430
     },
     {
         "name": "UltraCamXP WA",
-        "focal_length": 0.070,
-        "sensor_size": 0.000006,
+        "focal_length": 0.07,
+        "sensor_size": 6e-06,
         "pixels_along_track": 11310,
         "pixels_across_track": 17310
     },
     {
         "name": "UltraCamXp",
-        "focal_length": 0.100,
-        "sensor_size": 0.000006,
+        "focal_length": 0.1,
+        "sensor_size": 6e-06,
         "pixels_along_track": 11310,
         "pixels_across_track": 17310
+    },
+    {
+        "name": "DJI Zenmuse P1",
+        "focal_length": 0.035,
+        "sensor_size": 4.4e-06,
+        "pixels_along_track": 5460,
+        "pixels_across_track": 8192
     }
 ]

--- a/flight_planner_dialog.py
+++ b/flight_planner_dialog.py
@@ -801,8 +801,8 @@ class FlightPlannerDialog(QtWidgets.QDialog, FORM_CLASS):
                                                         'Enter camera name:')
             if pressed_ok:
                 new_camera = Camera(camera_name,
-                                    self.doubleSpinBoxFocalLength.value(),
-                                    self.doubleSpinBoxSensorSize.value(),
+                                    self.doubleSpinBoxFocalLength.value() / 1000,
+                                    self.doubleSpinBoxSensorSize.value() / 1000000,
                                     self.spinBoxPixelsAlongTrack.value(),
                                     self.spinBoxPixelsAcrossTrack.value())
                 new_camera.save()

--- a/flight_planner_dialog.py
+++ b/flight_planner_dialog.py
@@ -91,15 +91,15 @@ class FlightPlannerDialog(QtWidgets.QDialog, FORM_CLASS):
         self.mMapLayerComboBoxAoI.setFilters(QgsMapLayerProxyModel.PolygonLayer)
         self.mMapLayerComboBoxCorridor.setFilters(QgsMapLayerProxyModel.LineLayer)
 
-        self.comboBoxAltitudeType.addItems(["One altitude ASL for entire flight",
-            "Separate altitude ASL for each strip",
-            "Terrain following"])
+        self.comboBoxAltitudeType.addItems(["One Altitude ASL For Entire Flight",
+            "Separate Altitude ASL For Each Strip",
+            "Terrain Following"])
 
         # Set up ComboBox of camera
         self.cameras_file = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), 'cameras.json')
         with open(self.cameras_file, 'r', encoding='utf-8') as file:
-            self.cameras = [Camera(**camera) for camera in json.load(file)]
+            self.cameras = [Camera(**camera) for camera in sorted(json.load(file), key=lambda x : x['name'])]
             self.comboBoxCamera.addItems([camera.name for camera in self.cameras])
         if self.comboBoxCamera.count() > 0:
             self.comboBoxCamera.setItemText(0, 'Select camera or set parameters')
@@ -146,9 +146,9 @@ class FlightPlannerDialog(QtWidgets.QDialog, FORM_CLASS):
         worker.enabled.connect(self.pushButtonRunDesign.setEnabled)
         worker.enabled.connect(self.pushButtonRunControl.setEnabled)
 
-        if self.comboBoxAltitudeType.currentText() == 'Separate altitude ASL for each strip':
+        if self.comboBoxAltitudeType.currentText() == 'Separate Altitude ASL For Each Strip':
             thread.started.connect(worker.run_altitudeStrip)
-        elif self.comboBoxAltitudeType.currentText() == 'Terrain following':
+        elif self.comboBoxAltitudeType.currentText() == 'Terrain Following':
             thread.started.connect(worker.run_followingTerrain)
 
         thread.start()
@@ -230,16 +230,16 @@ class FlightPlannerDialog(QtWidgets.QDialog, FORM_CLASS):
 
     def on_comboBoxAltitudeType_activated(self, text):
         if isinstance(text, str):
-            if text in ['Separate altitude ASL for each strip', 'Terrain following'] \
+            if text in ['Separate Altitude ASL For Each Strip', 'Terrain Following'] \
                 and not self.mMapLayerComboBoxDTM.currentLayer():
                 QMessageBox.about(self, 'DTM needed', 'You must select DTM to use this option')
-                self.comboBoxAltitudeType.setCurrentText("One altitude ASL for entire flight")
+                self.comboBoxAltitudeType.setCurrentText("One Altitude ASL For Each Strip")
             elif text == 'Terrain following' and self.mMapLayerComboBoxDTM.currentLayer():
                 self.doubleSpinBoxSlopeThreshold.setEnabled(True)
             else:
                 self.doubleSpinBoxSlopeThreshold.setEnabled(False)
 
-            if self.comboBoxAltitudeType.currentText() != 'One altitude ASL for entire flight':
+            if self.comboBoxAltitudeType.currentText() != 'One Altitude ASL For Entire Flight':
                 self.checkBoxIncreaseOverlap.setChecked(False)
                 self.checkBoxIncreaseOverlap.setEnabled(False)
                 self.pushButtonGetHeights.setEnabled(False)
@@ -251,7 +251,7 @@ class FlightPlannerDialog(QtWidgets.QDialog, FORM_CLASS):
                 self.doubleSpinBoxMaxHeight.setEnabled(True)
                 self.doubleSpinBoxMinHeight.setEnabled(True)
 
-            if self.comboBoxAltitudeType.currentText() == 'Terrain following':
+            if self.comboBoxAltitudeType.currentText() == 'Terrain Following':
               self.radioButtonAltAGL.setEnabled(True)
             else:
                self.radioButtonAltAGL.setEnabled(False)
@@ -507,7 +507,7 @@ class FlightPlannerDialog(QtWidgets.QDialog, FORM_CLASS):
     def on_pushButtonRunDesign_clicked(self):
         """Push Button to make a flight plan."""
         attributes_exist = True
-        if self.comboBoxAltitudeType.currentText() in ['Separate altitude ASL for each strip', 'Terrain following']:
+        if self.comboBoxAltitudeType.currentText() in ['Separate Altitude ASL For Each Strip', 'Terrain Following']:
             if not hasattr(self, 'DTM'):
                 QMessageBox.about(self, 'DTM needed', 'You have to load DTM layer')
                 attributes_exist = False
@@ -653,7 +653,7 @@ class FlightPlannerDialog(QtWidgets.QDialog, FORM_CLASS):
                 print(e, traceback.format_exc())
                 save_error()
             else:
-                if self.comboBoxAltitudeType.currentText() == 'Separate altitude ASL for each strip':
+                if self.comboBoxAltitudeType.currentText() == 'Separate Altitude ASL For Each Strip':
                     if self.tabCorridor:
                         self.startWorker_updateAltitude(pointLayer=pc_lay,
                                                         theta=theta, 
@@ -681,7 +681,7 @@ class FlightPlannerDialog(QtWidgets.QDialog, FORM_CLASS):
                     self.pushButtonRunDesign.setEnabled(False)
                     self.pushButtonRunControl.setEnabled(False)
 
-                elif self.comboBoxAltitudeType.currentText() == 'Terrain following':
+                elif self.comboBoxAltitudeType.currentText() == 'Terrain Following':
                     self.startWorker_updateAltitude(pointLayer=pc_lay,
                                                     theta=theta,
                                                     distance=dist,

--- a/flight_planner_dialog_base.ui
+++ b/flight_planner_dialog_base.ui
@@ -24,7 +24,7 @@
      </property>
      <widget class="QWidget" name="tabFlightDesign">
       <attribute name="title">
-       <string>Flight design</string>
+       <string>Flight Design</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_5">
        <item row="0" column="0" rowspan="6">
@@ -40,7 +40,7 @@
            <item row="0" column="0" colspan="2">
             <widget class="QLabel" name="labelAoI">
              <property name="text">
-              <string>Area of Interest</string>
+              <string>Area of Interest (AoI)</string>
              </property>
             </widget>
            </item>
@@ -108,7 +108,7 @@
            <item row="0" column="0" colspan="2">
             <widget class="QLabel" name="labelCorridorLane">
              <property name="text">
-              <string>Corridor line</string>
+              <string>Corridor Line</string>
              </property>
             </widget>
            </item>
@@ -231,7 +231,7 @@
        <item row="2" column="1">
         <widget class="QLabel" name="labelOverlap">
          <property name="text">
-          <string>Overlap</string>
+          <string>Front Overlap</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -254,7 +254,7 @@
        <item row="3" column="1">
         <widget class="QLabel" name="labelSidelap">
          <property name="text">
-          <string>Sidelap</string>
+          <string>Side Overlap</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -277,7 +277,7 @@
        <item row="4" column="1">
         <widget class="QLabel" name="labelMultipleBase">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;multiple of base exceed AoI&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Multiple of Base Exceed AoI&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -300,7 +300,7 @@
        <item row="5" column="1">
         <widget class="QLabel" name="labelExceedExtremeStrips">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;first and last strip exceed AoI&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p>First and Last Strip Exceed AoI&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -323,14 +323,14 @@
        <item row="6" column="0">
         <widget class="QLabel" name="labelAltitudeType">
          <property name="text">
-          <string>Altitude type:</string>
+          <string>Altitude Type:</string>
          </property>
         </widget>
        </item>
        <item row="6" column="1">
         <widget class="QLabel" name="labelSlopeWaypoints">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;slope threshold&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p>Slope Threshold&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -388,7 +388,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="labelMinHeight">
             <property name="text">
-             <string>terrain's minimum height</string>
+             <string>Terrain's Minimum Height</string>
             </property>
            </widget>
           </item>
@@ -414,14 +414,14 @@
           <item row="0" column="2">
            <widget class="QPushButton" name="pushButtonGetHeights">
             <property name="text">
-             <string>Get heights from DTM</string>
+             <string>Get Heights from DTM</string>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="labelMaxHeight">
             <property name="text">
-             <string>terrain's maximum height</string>
+             <string>Terrain's Maximum Height</string>
             </property>
            </widget>
           </item>
@@ -447,7 +447,7 @@
           <item row="1" column="2">
            <widget class="QCheckBox" name="checkBoxIncreaseOverlap">
             <property name="text">
-             <string>Increase overlap/sidelap due to
+             <string>Increase front/side overlap due to
 min and max terrain's height</string>
             </property>
            </widget>
@@ -481,13 +481,13 @@ min and max terrain's height</string>
      </widget>
      <widget class="QWidget" name="tabQualityControl">
       <attribute name="title">
-       <string>Quality control</string>
+       <string>Quality Control</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
        <item row="0" column="0">
         <widget class="QLabel" name="labelProjectionCentres">
          <property name="text">
-          <string>Projection centres layer</string>
+          <string>Projection Centres Layer</string>
          </property>
         </widget>
        </item>
@@ -566,7 +566,7 @@ min and max terrain's height</string>
        <item row="5" column="2" colspan="2">
         <widget class="QLabel" name="labelIterationThreshold">
          <property name="text">
-          <string>iteration threshold</string>
+          <string>Iteration Threshold</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -615,21 +615,21 @@ min and max terrain's height</string>
           <item>
            <widget class="QCheckBox" name="checkBoxFootprint">
             <property name="text">
-             <string>Photo footprint</string>
+             <string>Photo Footprint</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="checkBoxOverlapImages">
             <property name="text">
-             <string>Number of overlap images</string>
+             <string>Number of Overlapping Images</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="checkBoxGSDmap">
             <property name="text">
-             <string>GSD map</string>
+             <string>GSD Map</string>
             </property>
            </widget>
           </item>
@@ -700,14 +700,17 @@ min and max terrain's height</string>
    <item row="1" column="1">
     <widget class="QPushButton" name="pushButtonSaveCamera">
      <property name="text">
-      <string>Save camera</string>
+      <string>Save Camera</string>
      </property>
     </widget>
    </item>
    <item row="2" column="3">
     <widget class="QLabel" name="labelPixelsAlongTrack">
      <property name="text">
-      <string>Image along track</string>
+      <string>Image Height</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -752,21 +755,27 @@ min and max terrain's height</string>
    <item row="1" column="2">
     <widget class="QPushButton" name="pushButtonDeleteCamera">
      <property name="text">
-      <string>Delete camera</string>
+      <string>Delete Camera</string>
      </property>
     </widget>
    </item>
    <item row="0" column="3">
     <widget class="QLabel" name="labelFocalLength">
      <property name="text">
-      <string>Focal length</string>
+      <string>Focal Length</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
    <item row="3" column="3">
     <widget class="QLabel" name="labelPixelsAcrossTrack">
      <property name="text">
-      <string>Image across track</string>
+      <string>Image Width</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -792,7 +801,10 @@ min and max terrain's height</string>
    <item row="1" column="3">
     <widget class="QLabel" name="labelSensorSize">
      <property name="text">
-      <string>Sensor pixel size</string>
+      <string>Sensor Pixel Size</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
- Changes to some formatting which includes capitalisation of the labels and aligning the camera parameter labels to the right. Makes it look more readable
- Added "(AoI)" to the Area of Interest label so it is more obvious what it stands for
- Rename some labels for easier understanding (such as the front/side overlaps) which is generally used in drones
- Bug: Camera saving was not saving focal length and sensor size correctly due to unit size conversions
- Added DJI's Zenmuse P1 camera to cameras.json